### PR TITLE
Add basic record and play functionality

### DIFF
--- a/core/adapter.c
+++ b/core/adapter.c
@@ -1195,6 +1195,8 @@ void adapter_clean()
 {
   int i;
   s_adapter* adapter;
+  bool saved_events = false;
+
   for(i=0; i<MAX_CONTROLLERS; ++i)
   {
     adapter = adapter_get(i);
@@ -1213,6 +1215,11 @@ void adapter_clean()
         if(adapter->ctype == C_TYPE_SIXAXIS)
         {
           sixaxis_close(i);
+          if(gimx_params.record && !saved_events)
+          {
+            sixaxis_save_events();
+            saved_events = true;
+          }
         }
 #ifndef WIN32
         else if(adapter->ctype == C_TYPE_DS4)

--- a/core/args.c
+++ b/core/args.c
@@ -83,6 +83,8 @@ static void usage()
   printf("  --log filename: write messages into a log file instead of the standard output.\n");
   printf("    filename: The name of the log file, in the ~/.gimx/log directory (make sure this folder exists).\n");
   printf("  --skip_leds: Filter out set led commands from FFB command stream (performance tweak for G27/G29 wheels on small targets).\n");
+  printf("  --record filename: write events into a file.\n");
+  printf("  --play filename: read events from a file.\n");
 }
 
 /*
@@ -158,6 +160,8 @@ int args_read(int argc, char *argv[], s_gimx_params* params)
     {"refresh", required_argument, 0, 'r'},
     {"src",     required_argument, 0, 's'},
     {"type",    required_argument, 0, 't'},
+    {"record",  required_argument, 0, 'o'},
+    {"play",    required_argument, 0, 'y'},
     {"version", no_argument,       0, 'v'},
     {0, 0, 0, 0}
   };
@@ -167,7 +171,7 @@ int args_read(int argc, char *argv[], s_gimx_params* params)
     /* getopt_long stores the option index here. */
     int option_index = 0;
 
-    c = getopt_long (argc, argv, "b:c:d:e:h:k:l:p:r:s:t:vm", long_options, &option_index);
+    c = getopt_long (argc, argv, "b:c:d:e:h:k:l:p:r:s:t:o:y:vm", long_options, &option_index);
 
     /* Detect the end of the options. */
     if (c == -1)
@@ -379,6 +383,18 @@ int args_read(int argc, char *argv[], s_gimx_params* params)
             ret = -1;
           }
         }
+        break;
+
+      case 'o':
+        params->events_file = optarg;
+        params->record = 1;
+        printf(_("global option -o with value `%s'\n"), optarg);
+        break;
+
+      case 'y':
+        params->events_file = optarg;
+        params->play = 1;
+        printf(_("global option -y with value `%s'\n"), optarg);
         break;
 
       case 'v':

--- a/core/include/connectors/sixaxis.h
+++ b/core/include/connectors/sixaxis.h
@@ -13,5 +13,10 @@
 int sixaxis_connect(int sixaxis_number, int dongle_index, const char * bdaddr_dst);
 void sixaxis_close(int sixaxis_number);
 int sixaxis_send_interrupt(int sixaxis_number, s_report_ds3* buf);
+int sixaxis_record_event(int sixaxis_number, s_report_ds3* buf);
+int sixaxis_play_events();
+FILE* get_events_file();
+void close_events_file();
+int sixaxis_save_events();
 
 #endif

--- a/core/include/gimx.h
+++ b/core/include/gimx.h
@@ -47,9 +47,13 @@ typedef struct
   char * logfilename;
   FILE * logfile;
   int skip_leds;
+  int record;
+  int play;
+  char* events_file;
 } s_gimx_params;
 
 extern s_gimx_params gimx_params;
+extern uint64_t gimx_timer_start;
 
 #define gprintf(...) if(gimx_params.status) printf(__VA_ARGS__)
 #define ncprintf(...) if(!gimx_params.curses) printf(__VA_ARGS__)
@@ -65,5 +69,8 @@ int ignore_event(GE_Event*);
 #define REGISTER_FUNCTION gpoll_register_fd
 #define REMOVE_FUNCTION gpoll_remove_fd
 #endif
+
+void gimx_start_timer();
+uint64_t timeval_to_usec(struct timeval tv);
 
 #endif /* GIMX_H_ */

--- a/core/include/play.h
+++ b/core/include/play.h
@@ -1,0 +1,13 @@
+/*
+ * play.h
+ *
+ *  Created on: 14 dec. 2016
+ *      Author: Leo Vidarte <lvidarte@gmail.com>
+ */
+
+#ifndef PLAY_H_
+#define PLAY_H_
+
+void play();
+
+#endif /* PLAY_H_ */

--- a/core/mainloop.c
+++ b/core/mainloop.c
@@ -7,6 +7,7 @@
 #include <gpoll.h>
 #include <gtimer.h>
 #include <gusb.h>
+#include <unistd.h>
 #include "gimx.h"
 #include "calibration.h"
 #include "macros.h"
@@ -40,6 +41,8 @@ void mainloop()
   GE_Event* event;
   unsigned int running_macros;
   int timer = -1;
+  int wait = 1;
+  int wait_sec = 10;
 
   if(!adapter_get(0)->bdaddr_dst || adapter_get(0)->ctype == C_TYPE_DS4)
   {
@@ -64,6 +67,22 @@ void mainloop()
      * gpoll should always be executed as it drives the period.
      */
     gpoll();
+
+    if(wait)
+    {
+      gpoll();
+      gprintf("waiting %ds for connection\n", wait_sec);
+      sleep(wait_sec);
+      wait = 0;
+      if(gimx_params.record)
+      {
+        gimx_start_timer();
+        gprintf("------------- record!\n"); 
+      }
+      else {
+        gprintf("------------- start!\n"); 
+      }
+    }
 
     ginput_periodic_task();
 

--- a/core/mainloop.c
+++ b/core/mainloop.c
@@ -70,7 +70,7 @@ void mainloop()
 
     if(wait)
     {
-      gpoll();
+      gpoll(); // Second call for the second adapter
       gprintf("waiting %ds for connection\n", wait_sec);
       sleep(wait_sec);
       wait = 0;

--- a/core/play.c
+++ b/core/play.c
@@ -1,0 +1,37 @@
+/*
+ Copyright (c) 2016 Mathieu Laurendeau <mat.lau@laposte.net>
+ License: GPLv3
+ */
+
+#include <ginput.h>
+#include <gpoll.h>
+#include <gtimer.h>
+#include <gusb.h>
+#include <unistd.h>
+#include "gimx.h"
+#include <stdio.h>
+#include <adapter.h>
+#include <connectors/usb_con.h>
+#include <report2event/report2event.h>
+#include "connectors/sixaxis.h"
+
+void play()
+{
+  int wait_sec = 5;
+
+  /*
+   * gpoll should always be executed as it drives the period.
+   */
+  gpoll();
+  gpoll(); // second call to init the second adapter
+
+  gprintf("waiting %ds for connection\n", wait_sec);
+  sleep(wait_sec);
+  gprintf("------------- play!\n"); 
+  gimx_start_timer();
+
+  if(sixaxis_play_events() <= 0)
+  {
+    fprintf(stderr, "error playing events\n");
+  }
+}

--- a/gimx-start-dual
+++ b/gimx-start-dual
@@ -1,16 +1,13 @@
 #!/bin/bash
 
+CONFIG_FILE="ps3-dual.xml"
+HOST_MAC="90:34:FC:DF:8A:E6"
+
 ADAPTER_1_HCI=1
 ADAPTER_1_MAC="08:A9:5A:26:3B:51"
 
 ADAPTER_2_HCI=2
 ADAPTER_2_MAC="34:C7:31:9C:9D:4E"
-
-GIMX_CONFIG="ps3-dual.xml"
-
-HOST_MAC="90:34:FC:DF:8A:E6"
-
-LOG="gimx.log"
 
 
 # Set MAC for the bluetooth adapter
@@ -34,9 +31,7 @@ set_adapter_mac $ADAPTER_1_HCI $ADAPTER_1_MAC
 set_adapter_mac $ADAPTER_2_HCI $ADAPTER_2_MAC
 
 
-echo "Launching gimx, logging on $LOG"
-
-gimx --status --nograb --config $GIMX_CONFIG \
+gimx --status --nograb --config $CONFIG_FILE \
      --type Sixaxis --hci $ADAPTER_1_HCI --bdaddr $HOST_MAC \
      --type Sixaxis --hci $ADAPTER_2_HCI --bdaddr $HOST_MAC \
      "$@"

--- a/gimx-start-dual
+++ b/gimx-start-dual
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+ADAPTER_1_HCI=1
+ADAPTER_1_MAC="08:A9:5A:26:3B:51"
+
+ADAPTER_2_HCI=2
+ADAPTER_2_MAC="34:C7:31:9C:9D:4E"
+
+GIMX_CONFIG="ps3-dual.xml"
+
+HOST_MAC="90:34:FC:DF:8A:E6"
+
+LOG="gimx.log"
+
+
+# Set MAC for the bluetooth adapter
+function set_adapter_mac
+{
+    local HCI=$1
+    local MAC=$2
+
+    echo $HCI $MAC
+
+    if [ $MAC != "$(bdaddr -i hci$HCI | grep Device | awk '{print $3}')" ]
+    then
+        echo "Setting the adapter $HCI to $MAC"
+        bdaddr -r -i hci$HCI $MAC 
+        sleep 1
+    fi
+}
+
+
+set_adapter_mac $ADAPTER_1_HCI $ADAPTER_1_MAC
+set_adapter_mac $ADAPTER_2_HCI $ADAPTER_2_MAC
+
+
+echo "Launching gimx, logging on $LOG"
+
+gimx --status --nograb --config $GIMX_CONFIG \
+     --type Sixaxis --hci $ADAPTER_1_HCI --bdaddr $HOST_MAC \
+     --type Sixaxis --hci $ADAPTER_2_HCI --bdaddr $HOST_MAC \
+     "$@"
+

--- a/shared/controller/include/ds3.h
+++ b/shared/controller/include/ds3.h
@@ -6,7 +6,9 @@
 #ifndef DS3_H_
 #define DS3_H_
 
+#include <sys/time.h>
 #include <defs.h>
+#include <stdint.h>
 
 typedef enum
 {
@@ -68,5 +70,12 @@ typedef struct GIMX_PACKED
   unsigned char acc_z[2];
   unsigned char gyro[2];
 } s_report_ds3;
+
+typedef struct GIMX_EVENT_DS3
+{
+  uint64_t usec;
+  int sixaxis_number;
+  s_report_ds3 state;
+} s_event_ds3;
 
 #endif /* DS3_H_ */


### PR DESCRIPTION
This is an experimental branch to add ps3 automation for two adapaters

Some code need to be rewrite/enhaced, for example: I'm using a fixing array of 1500 items to store the events, or I'm calling twice to `gpoll()` function for the second adapter. So this is a WIP :)

This code adds two new params to gimx: `--record` and `--play`

My config file is [here](https://gist.github.com/lvidarte/99c30e8650749a48ab819ad84128a070)

**Use examples**

Launch gimx as normal mode, for two adapters:

    ./gimx-start-dual

Before that, you need to change the following variables in `gimx-start-dual`:

    CONFIG_FILE="ps3-dual.xml
    HOST_MAC="90:34:FC:DF:8A:E6"

    ADAPTER_1_HCI=1
    ADAPTER_1_MAC="08:A9:5A:26:3B:51"

    ADAPTER_2_HCI=2
    ADAPTER_2_MAC="34:C7:31:9C:9D:4E""

Launch gimx for record events:

    ./gimx-start-dual --record events

Play events from file:

    ./gimx-start-dual --play events

